### PR TITLE
Fix wrong escape character

### DIFF
--- a/mc-biome-viewer.el
+++ b/mc-biome-viewer.el
@@ -160,7 +160,7 @@
                                   "mushroom fields" ?M
                                   "mushroom field shore" ?M
                                   "wooded hills" ?△
-                                  "mountain edge" ?\
+                                  "mountain edge" ?\\
                                   "stone shore" ?.
                                   "snowy beach" ?.
                                   "dark forest" ?T


### PR DESCRIPTION
This fixes the following loading error.

```
Load error for /home/syohei/tmp/mc-biome-viewer/mc-biome-viewer.el:
(error Invalid escape character syntax)
```